### PR TITLE
Option to Prune Objects

### DIFF
--- a/CRLoom/NSManagedObject+CRLoom.h
+++ b/CRLoom/NSManagedObject+CRLoom.h
@@ -82,6 +82,12 @@
  @param batchSize The numbers of objects processed that should trigger a save to the 
  managed object context. A value of 0 will have no save occur, a value of NSUIntegerMax
  will have 1 save occur after processing all objects.
+ @param pruneExistingObjects Whether or not the data should be treated as a full GET and
+ delete local objects that are not present. Sometimes API's won't specify deletes, API's
+ simpily provide a full get from an API and any object existing locally, that is not in 
+ the response from the API should be deleted, setting pruneExistingObjects will delete
+ any local NSManagedObject instances of this type that aren't present in the data being
+ imported
  @param error An error pointer that will be returned hydrated if there is any problem
  @return An array of the objects created
  */

--- a/CRLoom/NSManagedObject+CRLoom.h
+++ b/CRLoom/NSManagedObject+CRLoom.h
@@ -91,6 +91,7 @@
              withCache:(NSCache*)cache
       guaranteedInsert:(BOOL)guaranteedInsert
        saveOnBatchSize:(NSUInteger)batchSize
+  pruneExistingObjects:(BOOL)pruneExistingObjects
                  error:(NSError* __autoreleasing *)error;
 
 /**

--- a/CRLoom/NSManagedObject+CRLoom.m
+++ b/CRLoom/NSManagedObject+CRLoom.m
@@ -240,10 +240,9 @@ NSArray * CRIdentifierValuesFromDataWithKey(NSArray *data, NSString *identifierK
                          error:(NSError* __autoreleasing *)error {
     NSArray *idsToImport = [data valueForKeyPath:[@"@distinctUnionOfObjects." stringByAppendingString:[self uniqueDataIdentifierKey]]];
     NSArray *existingObjects = [[moc executeFetchRequest:[self emptyFetchRequest] error:error] mutableCopy];
-    NSArray *objectsToDelete = [existingObjects filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+    [[existingObjects filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return ![idsToImport containsObject:[evaluatedObject valueForKey:[self uniqueModelIdentifierKey]]];
-    }]];
-    [objectsToDelete enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    }]] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [moc deleteObject:obj];
     }];
 }

--- a/CRLoom/NSManagedObjectImportOperation.h
+++ b/CRLoom/NSManagedObjectImportOperation.h
@@ -10,10 +10,11 @@
 
 @interface NSManagedObjectImportOperation : NSOperation
 
-+ (id)operationWithData:(id)data
++ (instancetype)operationWithData:(id)data
      managedObjectClass:(Class)class
        guaranteedInsert:(BOOL)guaranteedInsert
         saveOnBatchSize:(NSUInteger)batchSize
+    pruneMissingObjects:(BOOL)pruneMissingObjects
                useCache:(BOOL)useCache
                   error:(NSError* __autoreleasing *)error;
 

--- a/CRLoomDemo/CRLoomDemo/CRLDAppDelegate.m
+++ b/CRLoomDemo/CRLoomDemo/CRLDAppDelegate.m
@@ -139,6 +139,7 @@ void generateRandomData() {
                                                                                       managedObjectClass:[Job class]
                                                                                         guaranteedInsert:NO
                                                                                          saveOnBatchSize:25
+                                                                                     pruneMissingObjects:NO
                                                                                                 useCache:NO
                                                                                                    error:&error];
         
@@ -146,6 +147,7 @@ void generateRandomData() {
                                                                                                managedObjectClass:[Person class]
                                                                                                  guaranteedInsert:NO
                                                                                                   saveOnBatchSize:25
+                                                                                              pruneMissingObjects:NO
                                                                                                          useCache:useCache
                                                                                                             error:&error];
         NSOperationQueue *queue = [[NSOperationQueue alloc] init];
@@ -157,12 +159,14 @@ void generateRandomData() {
               withCache:nil
        guaranteedInsert:YES
         saveOnBatchSize:25
+   pruneExistingObjects:NO
                   error:&error];
         [Person importData:data[@"people"]
                intoContext:[self managedObjectContext]
                  withCache:nil
           guaranteedInsert:YES
            saveOnBatchSize:25
+      pruneExistingObjects:NO
                      error:&error];
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ CRLoom is a framework for helping with the import, update and querying of `NSMan
 ### `NSManagedObjectImportOperation`
 This is an `NSOperation` subclass that created via
 ```Objective-C
-+ (id)operationWithData:(id)data
-     managedObjectClass:(Class)class
-       guaranteedInsert:(BOOL)guaranteedInsert
-        saveOnBatchSize:(NSUInteger)batchSize
-               useCache:(BOOL)useCache
-                  error:(NSError* __autoreleasing *)error;
++ (instanceType)operationWithData:(id)data
+               managedObjectClass:(Class)class
+                 guaranteedInsert:(BOOL)guaranteedInsert
+                  saveOnBatchSize:(NSUInteger)batchSize
+							pruneMissingObjects:(BOOL)pruneMissingObjects
+                         useCache:(BOOL)useCache
+                            error:(NSError* __autoreleasing *)error;
 ```
 This operation can be added to an `NSOperationQueue` and will thread the work of importing the data. Setting `useCache` to `YES` will have the operation provide an `NSCache` to the thread doing the import work that will be used as a first layer to check to find existing objects before entire fetch requests are used.
 


### PR DESCRIPTION
This allows for an `NSOperation` or direct `NSManagedObject` API to be used to import data and delete any objects held locally that are not present in the data about to be imported. This is good for API's that don't provided an `updated-since` to parameter when `GET`ing data. In these cases data can be imported and any local objects that have been deleted from the server will be deleted locally because they are not present in the full `GET` data about to be imported.
